### PR TITLE
Implement `snappl.DiaObject`

### DIFF
--- a/campari/AllASPFuncs.py
+++ b/campari/AllASPFuncs.py
@@ -20,7 +20,6 @@ from astropy.utils.exceptions import AstropyWarning
 from erfa import ErfaWarning
 from galsim import roman
 import healpy as hp
-from matplotlib import pyplot as plt
 from numpy.linalg import LinAlgError
 from roman_imsim.utils import roman_utils
 from scipy.interpolate import RegularGridInterpolator
@@ -28,6 +27,7 @@ import yaml
 
 # SN-PIT
 from snappl.image import OpenUniverse2024FITSImage
+from snappl.diaobject import DiaObject
 from snpit_utils.config import Config
 from snpit_utils.logger import SNLogger
 from snappl.psf import PSF
@@ -500,6 +500,7 @@ def construct_transient_scene(x, y, pointing, sca, stampsize=25, x_center=None,
     x, y: ints, pixel coordinates where the cutout is centered in the SCA
     pointing, sca: ints, the pointing and SCA of the image
     stampsize = int, size of cutout image used
+    TODO: this defn below isn't correct
     x_center and y_center: floats, x and y location of the object in the SCA.
     sed: galsim.sed.SED object, the SED of the source
     flux: float, If you are using this function to build a model grid point,
@@ -759,7 +760,7 @@ def fetch_images(exposures, ra, dec, size, subtract_background, roman_path, obje
     return cutout_image_list, image_list, exposures
 
 
-def get_object_info(ID, parq, band, snpath, roman_path, obj_type):
+def get_object_info(ID, parq, band, snpath, roman_path, obj_type, collection='ou2024'):
 
     """Fetch some info about an object given its ID.
     Inputs:
@@ -795,7 +796,9 @@ def get_object_info(ID, parq, band, snpath, roman_path, obj_type):
 
     pointing, sca = radec2point(ra, dec, band, roman_path)
 
-    return ra, dec, pointing, sca, start, end, peak
+    #### Implementing dia object
+    obj = DiaObject.find_objects(collection=collection, id=ID)[0]
+    return obj.ra, obj.dec, obj.mjd_start, obj.mjd_end, obj.mjd_peak
 
 
 def get_weights(images, ra, dec, gaussian_var=1000, cutoff=4):

--- a/campari/AllASPFuncs.py
+++ b/campari/AllASPFuncs.py
@@ -349,7 +349,7 @@ def construct_static_scene(ra, dec, sca_wcs, x_loc, y_loc, stampsize, psf=None, 
     return psfs
 
 
-def find_all_exposures(ra, dec, transient_start, transient_end, band, maxbg=None,
+def find_all_exposures(diaobj, band, maxbg=None,
                        maxdet=None, return_list=False,
                        roman_path=None, pointing_list=None, sca_list=None,
                        truth="simple_model", image_selection_start=-np.inf, image_selection_end=np.inf):
@@ -382,6 +382,10 @@ def find_all_exposures(ra, dec, transient_start, transient_end, band, maxbg=None
         - date: the MJD of the exposure
         - detected: whether the exposure contains a detection or not.
     """
+    transient_start = diaobj.mjd_start
+    transient_end = diaobj.mjd_end
+    ra = diaobj.ra
+    dec = diaobj.dec
     f = fits.open(roman_path +
                   "/RomanTDS/Roman_TDS_obseq_11_6_23_radec.fits")[1]
     f = f.data
@@ -394,6 +398,10 @@ def find_all_exposures(ra, dec, transient_start, transient_end, band, maxbg=None
     if not (isinstance(maxdet, (int, type(None))) & isinstance(maxbg, (int, type(None)))):
         raise TypeError("maxdet and maxbg must be integers or None, " +
                         f"not {type(maxdet), type(maxbg)}. Their values are {maxdet, maxbg}")
+    if transient_start is None:
+        transient_start = -np.inf
+    if transient_end is None:
+        transient_end = np.inf
 
     # Rob's database method! :D
 
@@ -407,6 +415,7 @@ def find_all_exposures(ra, dec, transient_start, transient_end, band, maxbg=None
     res = pd.DataFrame(result.json())[["pointing", "sca", "mjd", "filter"]]
     res.rename(columns={"mjd": "date"}, inplace=True)
     res = res.loc[res["filter"] == band].copy()
+    SNLogger.debug(f"before cuts: \n{res}")
 
     # The first date cut selects images that are detections, the second
     # selects detections within the requested light curve window.
@@ -784,6 +793,7 @@ def get_object_info(ID, parq, band, snpath, roman_path, obj_type, collection='ou
 
     df = df.loc[df.id == ID]
     ra, dec = df.ra.values[0], df.dec.values[0]
+    SNLogger.debug(f"RA, DEC of {obj_type} {ID}: {ra, dec}")
 
     if obj_type == "SN":
         start = df.start_mjd.values
@@ -798,7 +808,7 @@ def get_object_info(ID, parq, band, snpath, roman_path, obj_type, collection='ou
 
     #### Implementing dia object
     obj = DiaObject.find_objects(collection=collection, id=ID)[0]
-    return obj.ra, obj.dec, obj.mjd_start, obj.mjd_end, obj.mjd_peak
+    return obj
 
 
 def get_weights(images, ra, dec, gaussian_var=1000, cutoff=4):
@@ -1586,7 +1596,7 @@ def extract_star_from_parquet_file_and_write_to_csv(parquet_file, sn_path,
     SNLogger.info(f"Saved to {output_path}")
 
 
-def run_one_object(ID=None, ra=None, dec=None, object_type=None, exposures=None,
+def run_one_object(diaobj=None, object_type=None, exposures=None,
                    roman_path=None, sn_path=None, size=None, band=None, fetch_SED=None, sedlist=None,
                    use_real_images=None, use_roman=None, subtract_background=None,
                    make_initial_guess=None, initial_flux_guess=None, weighting=None, method=None,
@@ -1609,8 +1619,8 @@ def run_one_object(ID=None, ra=None, dec=None, object_type=None, exposures=None,
 
     if use_real_images:
         # Using exposures Table, load those Pointing/SCAs as images.
-        cutout_image_list, image_list, exposures = fetch_images(exposures, ra, dec, size, subtract_background,
-                                                                roman_path, object_type)
+        cutout_image_list, image_list, exposures = fetch_images(exposures, diaobj.ra, diaobj.dec, size,
+                                                                subtract_background, roman_path, object_type)
         # We didn't simulate anything, so set these simulation only vars to none.
         sim_galra = None
         sim_galdec = None
@@ -1619,7 +1629,7 @@ def run_one_object(ID=None, ra=None, dec=None, object_type=None, exposures=None,
         # Simulate the images of the SN and galaxy.
         banner("Simulating Images")
         sim_lc, util_ref, image_list, cutout_image_list, sim_galra, sim_galdec = \
-            simulate_images(num_total_images, num_detect_images, ra, dec,
+            simulate_images(num_total_images, num_detect_images, diaobj.ra, diaobj.dec,
                             sim_galaxy_scale, sim_galaxy_offset,
                             do_xshift, do_rotation, noise=noise,
                             use_roman=use_roman, roman_path=roman_path,
@@ -1635,7 +1645,7 @@ def run_one_object(ID=None, ra=None, dec=None, object_type=None, exposures=None,
     if not grid_type == "none":
         if object_type == "star":
             SNLogger.warning("For fitting stars, you probably dont want a grid.")
-        ra_grid, dec_grid = make_grid(grid_type, cutout_image_list, ra, dec,
+        ra_grid, dec_grid = make_grid(grid_type, cutout_image_list, diaobj.ra, diaobj.dec,
                                       percentiles=percentiles, single_ra=sim_galra,
                                       single_dec=sim_galdec, spacing=spacing)
     else:
@@ -1665,7 +1675,7 @@ def run_one_object(ID=None, ra=None, dec=None, object_type=None, exposures=None,
     #if use_real_images and object_type == "SN" and num_detect_images > 1:
     if False: # This is a temporary fix to not calculate the confusion metric.
         sed = get_galsim_SED(ID, exposures, sn_path, fetch_SED=False)
-        object_x, object_y = image_list[0].get_wcs().world_to_pixel(ra, dec)
+        object_x, object_y = image_list[0].get_wcs().world_to_pixel(diaobj.ra, diaobj.dec)
         # object_x and object_y are the exact coords of the SN in the SCA frame.
         # x and y are the pixels the image has been cut out on, and
         # hence must be ints. Before, I had object_x and object_y as SN coords in the cutout frame, hence this switch.
@@ -1699,7 +1709,7 @@ def run_one_object(ID=None, ra=None, dec=None, object_type=None, exposures=None,
         drawing_psf = None if use_roman else airy
 
         whole_sca_wcs = image.get_wcs()
-        object_x, object_y = whole_sca_wcs.world_to_pixel(ra, dec)
+        object_x, object_y = whole_sca_wcs.world_to_pixel(diaobj.ra, diaobj.dec)
 
         # Build the model for the background using the correct psf and the
         # grid we made in the previous section.
@@ -1811,7 +1821,7 @@ def run_one_object(ID=None, ra=None, dec=None, object_type=None, exposures=None,
     # Get the weights
 
     if weighting:
-        wgt_matrix = get_weights(cutout_image_list, ra, dec)
+        wgt_matrix = get_weights(cutout_image_list, diaobj.ra, diaobj.dec)
     else:
         wgt_matrix = np.ones(psf_matrix.shape[1])
 
@@ -1998,4 +2008,3 @@ def make_sim_param_grid(params):
     flat_grid = np.array(nd_grid, dtype=float).reshape(len(params), -1)
     SNLogger.debug(f"Created a grid of simulation parameters with a total of {flat_grid.shape[1]} combinations.")
     return flat_grid
-

--- a/campari/RomanASP.py
+++ b/campari/RomanASP.py
@@ -66,9 +66,9 @@ def main():
     #     cfg = None
     except RuntimeError as e:
         if str(e) == "No default config defined yet; run Config.init(configfile)":
-            sys.stderr.write( "Error, no configuration file defined.\n"
-                              "Either run campari with -c <configfile>\n"
-                              "or set the SNPIT_CONFIG environment varaible.\n")
+            sys.stderr.write("Error, no configuration file defined.\n"
+                             "Either run campari with -c <configfile>\n"
+                             "or set the SNPIT_CONFIG environment varaible.\n")
             sys.exit(1)
         else:
             raise

--- a/campari/tests/test_runner.py
+++ b/campari/tests/test_runner.py
@@ -197,8 +197,8 @@ def test_lookup_object_info(cfg):
     ra, dec, start, end = runner.lookup_object_info(test_args.SNID)
     assert ra == 7.551093401915147
     assert dec == -44.80718106491529
-    assert start[0] == 62450.0
-    assert end[0] == 62881.0
+    assert start == 62450.0
+    assert end == 62881.0
 
 
 def test_get_exposures(cfg):

--- a/examples/perlmutter/campari_config_jupyter.yaml
+++ b/examples/perlmutter/campari_config_jupyter.yaml
@@ -1,5 +1,5 @@
 ou24:
-  config_file: /pscratch/sd/c/cmeldorf/campari/examples/perlmutter/tds.yaml
+  config_file: /pscratch/sd/c/cmeldorf/campari/examples/perlmutter/tds_jupyter.yaml
   sn_truth_dir: /dvs_ro/cfs/cdirs/lsst/www/DESC_TD_PUBLIC/Roman+DESC/PQ+HDF5_ROMAN+LSST_LARGE
   sims_sed_library: /pscratch/sd/c/cmeldorf/rubin_sim_data/sims_sed_library
 


### PR DESCRIPTION
In this PR we implement the new DiaObject class that carries information about a single transient (or star). 
1. [ ] Several functions that took ID, ra, dec, transient_start and transient_end as arguments now take a single DiaObject instance.
2. [ ] 