### PR TITLE
Updating to work alongside snappl PR that replaces `input_wcs`

### DIFF
--- a/campari/model_building.py
+++ b/campari/model_building.py
@@ -239,7 +239,7 @@ def generate_guess(imlist, ra_grid, dec_grid):
 
 
 def construct_static_scene(ra=None, dec=None, sca_wcs=None, x_loc=None, y_loc=None, stampsize=None,
-                           psf=None, pixel=False, util_ref=None, band=None):
+                           psf=None, pixel=False, util_ref=None, band=None, image=None):
     """Constructs the background model around a certain image (x,y) location
     and a given array of RA and DECs.
 
@@ -291,7 +291,8 @@ def construct_static_scene(ra=None, dec=None, sca_wcs=None, x_loc=None, y_loc=No
     pointing = util_ref.visit
     sca = util_ref.sca
 
-    psf_object = PSF.get_psf_object("ou24PSF", pointing=pointing, sca=sca, size=stampsize, include_photonOps=False)
+    psf_object = PSF.get_psf_object("ou24PSF", pointing=pointing, sca=sca, size=stampsize,
+                                    include_photonOps=False, seed=None, image=image)
     # See run_one_object documentation to explain this pixel coordinate conversion.
     x_loc = int(np.floor(x_loc + 0.5))
     y_loc = int(np.floor(y_loc + 0.5))
@@ -301,7 +302,7 @@ def construct_static_scene(ra=None, dec=None, sca_wcs=None, x_loc=None, y_loc=No
         if a % 50 == 0:
             SNLogger.debug(f"Drawing PSF {a} of {num_grid_points}")
         psfs[:, a] = psf_object.get_stamp(
-            x0=x_loc, y0=y_loc, x=x, y=y, flux=1.0, seed=None, input_wcs=sca_wcs
+            x0=x_loc, y0=y_loc, x=x, y=y, flux=1.0
         ).flatten()
 
     return psfs
@@ -309,7 +310,7 @@ def construct_static_scene(ra=None, dec=None, sca_wcs=None, x_loc=None, y_loc=No
 
 def construct_transient_scene(
     x0=None, y0=None, pointing=None, sca=None, stampsize=25, x=None,
-    y=None, sed=None, flux=1, photOps=True, sca_wcs=None
+    y=None, sed=None, flux=1, photOps=True, sca_wcs=None, image=None
 ):
     """Constructs the PSF around the point source (x,y) location, allowing for
         some offset from the center.
@@ -357,9 +358,9 @@ def construct_transient_scene(
         SNLogger.warning("NOT USING PHOTON OPS IN PSF SOURCE")
 
     psf_object = PSF.get_psf_object(
-        "ou24PSF_slow", pointing=pointing, sca=sca, size=stampsize, include_photonOps=photOps
+        "ou24PSF_slow", pointing=pointing, sca=sca, size=stampsize, include_photonOps=photOps, image=image
     )
-    psf_image = psf_object.get_stamp(x0=x0, y0=y0, x=x, y=y, flux=1.0, seed=None, input_wcs=sca_wcs)
+    psf_image = psf_object.get_stamp(x0=x0, y0=y0, x=x, y=y, flux=1.0, seed=None)
 
     return psf_image.flatten()
 

--- a/campari/run_one_object.py
+++ b/campari/run_one_object.py
@@ -174,7 +174,7 @@ def run_one_object(diaobj=None, object_type=None, image_list=None, size=None, ba
                 construct_static_scene(ra_grid, dec_grid,
                                        whole_sca_wcs,
                                        object_x, object_y, size, psf=drawing_psf,
-                                       pixel=pixel,
+                                       pixel=pixel, image=image,
                                        util_ref=util_ref, band=band)
 
         if not subtract_background:
@@ -233,7 +233,7 @@ def run_one_object(diaobj=None, object_type=None, image_list=None, size=None, ba
                 psf_source_array =\
                     construct_transient_scene(x0=x, y0=y, pointing=pointing, sca=sca,
                                               stampsize=size, x=object_x,
-                                              y=object_y, sed=sed,
+                                              y=object_y, sed=sed, image=image,
                                               photOps=source_phot_ops, sca_wcs=whole_sca_wcs)
             else:
                 # NOTE: cutout_wcs_list is not being included in the zip above because in a different branch

--- a/campari/simulation.py
+++ b/campari/simulation.py
@@ -14,8 +14,6 @@ from snappl.psf import PSF
 from snpit_utils.config import Config
 from snpit_utils.logger import SNLogger
 
-
-
 # This supresses a warning because the Open Universe Simulations dates are not
 # FITS compliant.
 warnings.simplefilter("ignore", category=AstropyWarning)
@@ -201,11 +199,19 @@ def simulate_images(image_list=None, diaobj=None,
                 snx, sny = cutoutgalwcs.toImage(snra, sndec, units="deg")
                 stamp = galsim.Image(size, size, wcs=cutoutgalwcs)
                 SNLogger.debug(f"sed: {sed}")
-                supernova_image = \
-                    simulate_supernova(snx=cutout_loc[0], sny=cutout_loc[1], snx0=cutout_pixel[0], sny0=cutout_pixel[1],
-                                       flux=sim_lc[sn_im_index], sed=sed, source_phot_ops=source_phot_ops,
-                                       base_pointing=base_pointing, base_sca=base_sca, stampsize=size,
-                                       sca_wcs=full_image_wcs)
+                supernova_image = simulate_supernova(
+                    snx=cutout_loc[0],
+                    sny=cutout_loc[1],
+                    snx0=cutout_pixel[0],
+                    sny0=cutout_pixel[1],
+                    flux=sim_lc[sn_im_index],
+                    sed=sed,
+                    source_phot_ops=source_phot_ops,
+                    base_pointing=base_pointing,
+                    base_sca=base_sca,
+                    stampsize=size,
+                    image=image_object,
+                )
 
                 a += supernova_image
                 sn_storage.append(supernova_image)
@@ -220,7 +226,6 @@ def simulate_images(image_list=None, diaobj=None,
         cutout_object.mjd = image_object.mjd  # Temp fix, cutouts should inherit mjd from full image in snappl.
         cutout_object.band = image_object.band  # Temp fix, cutouts should inherit band from full image in snappl.
         cutout_image_list.append(cutout_object)
-
 
     lightcurve = campari_lightcurve_model(
         sim_lc=sim_lc,
@@ -341,7 +346,7 @@ def simulate_galaxy(bg_gal_flux=None, sim_galaxy_scale=None, deltafcn_profile=No
 
 def simulate_supernova(snx=None, sny=None, snx0=None, sny0=None, flux=None, sed=None,
                        source_phot_ops=None, base_pointing=None, base_sca=None, stampsize=None,
-                       random_seed=0, sca_wcs=None):
+                       random_seed=0, image=None):
     """This function simulates a supernova using the ou24PSF_slow PSF.
 
     Inputs:
@@ -366,8 +371,8 @@ def simulate_supernova(snx=None, sny=None, snx0=None, sny0=None, flux=None, sed=
     SNLogger.debug(f"source_phot_ops: {source_phot_ops} and sed {sed}")
 
     psf_object = PSF.get_psf_object("ou24PSF_slow", pointing=base_pointing, sca=base_sca,
-                                    size=stampsize, include_photonOps=source_phot_ops, sed=sed)
+                                    size=stampsize, include_photonOps=source_phot_ops, sed=sed, seed=None, image=image)
     psf_image = psf_object.get_stamp(x0=snx0, y0=sny0, x=snx, y=sny,
-                                     flux=flux, seed=None, input_wcs=sca_wcs)
+                                     flux=flux)
     SNLogger.debug(type(psf_image))
     return psf_image


### PR DESCRIPTION
In snappl  [PR 72](https://github.com/Roman-Supernova-PIT/snappl/pull/72) we remove the ability to pass a wcs to a psf object and instead optionally pass a snappl image object. This PR updates `campari` to work in this new mode.

- [ ] 