### PR TITLE
Removing Manual Fits Image to match new snappl paradigm

### DIFF
--- a/campari/RomanASP.py
+++ b/campari/RomanASP.py
@@ -131,6 +131,8 @@ def main():
                         help="Which collection of objects to use for lookup. "
                              "Default is 'ou24', the Open Universe 2024 catalog. 'manual'"
                              "will use the input ra and dec given by the user, and not perform any lookup.")
+    parser.add_argument("--image_source", type=str, default="ou2024", required=False,
+                        help="Which collection of images to use for lookup. ")
     ####################
     # FINDING THE IMAGES TO RUN SCENE MODELLING ON
 

--- a/campari/campari_runner.py
+++ b/campari/campari_runner.py
@@ -302,7 +302,7 @@ class campari_runner:
                 # cutout sized and the 4088 is used nowhere.
                 img = FITSImageStdHeaders(
                     header=None, data=np.zeros((4088, 4088)), noise=np.zeros((4088, 4088)),
-                    flags=np.zeros((4088, 4088)), path="none"
+                    flags=np.zeros((4088, 4088)), path="/dev/null"
                 )
                 img.mjd = faux_dates[i]
                 img.band = self.band

--- a/campari/campari_runner.py
+++ b/campari/campari_runner.py
@@ -10,7 +10,7 @@ import galsim
 
 # SN-PIT
 from snappl.diaobject import DiaObject
-from snappl.image import ManualFITSImage
+from snappl.image import FITSImageStdHeaders
 from snappl.sed import Flat_SED, OU2024_Truth_SED
 from snpit_utils.config import Config
 from snpit_utils.logger import SNLogger
@@ -299,12 +299,15 @@ class campari_runner:
                 # These data sizes are arbitary. I just need a data array present in order to perform the cutout,
                 # otherwise snappl throws an error. No data is actually placed into these images until they are
                 # cutout sized and the 4088 is used nowhere.
-                img = ManualFITSImage(
+                img = FITSImageStdHeaders(
                     header=None, data=np.zeros((4088, 4088)), noise=np.zeros((4088, 4088)),
-                    flags=np.zeros((4088, 4088)), pointing=self.base_pointing, sca=self.base_sca, band=self.band,
-                    mjd=faux_dates[i]
+                    flags=np.zeros((4088, 4088)), path="none"
                 )
+                img.mjd = faux_dates[i]
+                img.band = self.band
                 image_list.append(img)
+                img.pointing = self.base_pointing
+                img.sca = self.base_sca
 
         recovered_pointings = [a.pointing for a in image_list]
         if self.img_list is not None and not np.array_equiv(np.sort(recovered_pointings),

--- a/campari/simulation.py
+++ b/campari/simulation.py
@@ -230,8 +230,7 @@ def simulate_images(image_list=None, diaobj=None,
             cutout_object.noise = np.ones_like(a) * noise
         else:
             cutout_object.noise = np.ones_like(a)
-        the_mjd = image_object.mjd
-        cutout_object.mjd = the_mjd  # Temp fix, cutouts should inherit mjd from full image in snappl.
+        cutout_object.mjd = image_object.mjd # Temp fix, cutouts should inherit mjd from full image in snappl.
         cutout_object.band = image_object.band  # Temp fix, cutouts should inherit band from full image in snappl.
         cutout_image_list.append(cutout_object)
 

--- a/campari/simulation.py
+++ b/campari/simulation.py
@@ -230,7 +230,7 @@ def simulate_images(image_list=None, diaobj=None,
             cutout_object.noise = np.ones_like(a) * noise
         else:
             cutout_object.noise = np.ones_like(a)
-        cutout_object.mjd = image_object.mjd # Temp fix, cutouts should inherit mjd from full image in snappl.
+        cutout_object.mjd = image_object.mjd  # Temp fix, cutouts should inherit mjd from full image in snappl.
         cutout_object.band = image_object.band  # Temp fix, cutouts should inherit band from full image in snappl.
         cutout_image_list.append(cutout_object)
 

--- a/campari/simulation.py
+++ b/campari/simulation.py
@@ -5,6 +5,7 @@ import galsim
 import numpy as np
 import pandas as pd
 from astropy.utils.exceptions import AstropyWarning
+from astropy.io.fits import Header as header
 from erfa import ErfaWarning
 from roman_imsim.utils import roman_utils
 
@@ -65,8 +66,8 @@ def simulate_images(image_list=None, diaobj=None,
     Returns:
     sim_lc: list, the light curve of the supernova.
     util_ref: roman_utils object, used to get the PSF.
-    image_list: list of ManualFITSImage objects, the full images.
-    cutout_image_list: list of ManualFITSImage objects, the cutout images.
+    image_list: list of FITSImageStdHeaders objects, the full images.
+    cutout_image_list: list of FITSImageStdHeaders objects, the cutout images.
     galra: float, the RA of the galaxy.
     galdec: float, the DEC of the galaxy.
     """
@@ -132,7 +133,14 @@ def simulate_images(image_list=None, diaobj=None,
 
         wcs_dict = simulate_wcs(angle=rotation_angle, x_shift=x_shift, y_shift=y_shift,
                                 base_sca=base_sca, base_pointing=base_pointing, band=band)
-        image_object.set_fits_header(wcs_dict)
+        input_header = header(wcs_dict)
+        # Adding in other necessary header keywords.
+        input_header["MJD"] = image_object.mjd
+        input_header["BAND"] = image_object.band
+        input_header["POINTING"] = image_object.pointing
+        input_header["SCA"] = image_object.sca
+
+        image_object.set_fits_header(input_header)
 
         full_image_wcs = image_object.get_wcs()
 
@@ -222,8 +230,8 @@ def simulate_images(image_list=None, diaobj=None,
             cutout_object.noise = np.ones_like(a) * noise
         else:
             cutout_object.noise = np.ones_like(a)
-
-        cutout_object.mjd = image_object.mjd  # Temp fix, cutouts should inherit mjd from full image in snappl.
+        the_mjd = image_object.mjd
+        cutout_object.mjd = the_mjd  # Temp fix, cutouts should inherit mjd from full image in snappl.
         cutout_object.band = image_object.band  # Temp fix, cutouts should inherit band from full image in snappl.
         cutout_image_list.append(cutout_object)
 

--- a/campari/tests/test_campari.py
+++ b/campari/tests/test_campari.py
@@ -46,7 +46,7 @@ from campari.utils import (calc_mag_and_err,
                            campari_lightcurve_model)
 import snappl
 from snappl.diaobject import DiaObject
-from snappl.image import ManualFITSImage
+from snappl.image import FITSImageStdHeaders
 from snappl.imagecollection import ImageCollection
 from snpit_utils.config import Config
 from snpit_utils.logger import SNLogger
@@ -340,7 +340,7 @@ def test_make_regular_grid():
     test_dec = np.array([-44.263969, -44.263897, -44.263825, -44.263918, -44.263846,
                          -44.263774, -44.263868, -44.263796, -44.263724])
     for wcs in [snappl.wcs.AstropyWCS.from_header(wcs_dict)]:
-        img = ManualFITSImage(header=wcs_dict, data=np.zeros((25, 25)))
+        img = FITSImageStdHeaders(header=wcs_dict, path="none", data=np.zeros((25, 25)))
         ra_grid, dec_grid = make_regular_grid(img,
                                               spacing=3.0)
         np.testing.assert_allclose(ra_grid, test_ra, atol=1e-9), \
@@ -362,7 +362,7 @@ def test_make_adaptive_grid():
                                  / "testdata/images.npy")
         SNLogger.debug(f"compare_images shape: {compare_images.shape}")
         image = compare_images[0].reshape(11, 11)
-        img_obj = ManualFITSImage(header=wcs_dict, data=image)
+        img_obj = FITSImageStdHeaders(header=wcs_dict, data=image, path="none")
         ra_grid, dec_grid = make_adaptive_grid(img_obj, percentiles=[99])
         test_ra = [7.67356034, 7.67359491, 7.67362949, 7.67366407, 7.67369864,]
         test_dec = [-44.26425446, -44.26423765, -44.26422084, -44.26420403,
@@ -388,7 +388,7 @@ def test_make_contour_grid():
         compare_images = np.load(pathlib.Path(__file__).parent
                                  / "testdata/images.npy")
         image = compare_images[0].reshape(11, 11)
-        img_obj = ManualFITSImage(header=wcs_dict, data=image)
+        img_obj = FITSImageStdHeaders(header=wcs_dict, data=image, path="none")
         ra_grid, dec_grid = make_contour_grid(img_obj)
         msg = f"RA vals do not match to {atol:.1e}."
         np.testing.assert_allclose(ra_grid[:4], test_ra, atol=atol, rtol=1e-9), msg
@@ -565,8 +565,12 @@ def test_build_lc():
     cutout_image_list = []
 
     for i in range(len(explist["date"])):
-        img = ManualFITSImage(
-            header=None, data=np.zeros((4085, 4085)), noise=np.zeros((4085, 4085)), flags=np.zeros((4085, 4085)),
+        img = FITSImageStdHeaders(
+            header=None,
+            data=np.zeros((4085, 4085)),
+            noise=np.zeros((4085, 4085)),
+            flags=np.zeros((4085, 4085)),
+            path="none"
         )
         img.mjd = explist["date"][i]
         img.filter = explist["filter"][i]

--- a/campari/tests/test_campari.py
+++ b/campari/tests/test_campari.py
@@ -340,7 +340,7 @@ def test_make_regular_grid():
     test_dec = np.array([-44.263969, -44.263897, -44.263825, -44.263918, -44.263846,
                          -44.263774, -44.263868, -44.263796, -44.263724])
     for wcs in [snappl.wcs.AstropyWCS.from_header(wcs_dict)]:
-        img = FITSImageStdHeaders(header=wcs_dict, path="none", data=np.zeros((25, 25)))
+        img = FITSImageStdHeaders(header=wcs_dict, path="/dev/null", data=np.zeros((25, 25)))
         ra_grid, dec_grid = make_regular_grid(img,
                                               spacing=3.0)
         np.testing.assert_allclose(ra_grid, test_ra, atol=1e-9), \
@@ -362,7 +362,7 @@ def test_make_adaptive_grid():
                                  / "testdata/images.npy")
         SNLogger.debug(f"compare_images shape: {compare_images.shape}")
         image = compare_images[0].reshape(11, 11)
-        img_obj = FITSImageStdHeaders(header=wcs_dict, data=image, path="none")
+        img_obj = FITSImageStdHeaders(header=wcs_dict, data=image, path="/dev/null")
         ra_grid, dec_grid = make_adaptive_grid(img_obj, percentiles=[99])
         test_ra = [7.67356034, 7.67359491, 7.67362949, 7.67366407, 7.67369864,]
         test_dec = [-44.26425446, -44.26423765, -44.26422084, -44.26420403,
@@ -388,7 +388,7 @@ def test_make_contour_grid():
         compare_images = np.load(pathlib.Path(__file__).parent
                                  / "testdata/images.npy")
         image = compare_images[0].reshape(11, 11)
-        img_obj = FITSImageStdHeaders(header=wcs_dict, data=image, path="none")
+        img_obj = FITSImageStdHeaders(header=wcs_dict, data=image, path="/dev/null")
         ra_grid, dec_grid = make_contour_grid(img_obj)
         msg = f"RA vals do not match to {atol:.1e}."
         np.testing.assert_allclose(ra_grid[:4], test_ra, atol=atol, rtol=1e-9), msg
@@ -570,7 +570,7 @@ def test_build_lc():
             data=np.zeros((4085, 4085)),
             noise=np.zeros((4085, 4085)),
             flags=np.zeros((4085, 4085)),
-            path="none"
+            path="/dev/null"
         )
         img.mjd = explist["date"][i]
         img.filter = explist["filter"][i]

--- a/campari/tests/test_runner.py
+++ b/campari/tests/test_runner.py
@@ -197,7 +197,7 @@ def test_get_SED_list(cfg):
 
     img = FITSImageStdHeaders(
         header=None,
-        path="none",
+        path="/dev/null",
         data=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
         noise=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
         flags=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
@@ -269,7 +269,7 @@ def test_build_and_save_lc(cfg):
     for i in range(len(exposures["date"])):
         img = FITSImageStdHeaders(
             header=None,
-            path="none",
+            path="/dev/null",
             data=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
             noise=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
             flags=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),

--- a/campari/tests/test_runner.py
+++ b/campari/tests/test_runner.py
@@ -11,7 +11,7 @@ import pytest
 from campari.campari_runner import campari_runner
 from campari.utils import campari_lightcurve_model
 from snappl.diaobject import DiaObject
-from snappl.image import ManualFITSImage
+from snappl.image import FITSImageStdHeaders
 from snappl.imagecollection import ImageCollection
 from snpit_utils.config import Config
 from snpit_utils.logger import SNLogger
@@ -195,9 +195,12 @@ def test_get_SED_list(cfg):
     test_args.object_collection = "ou24"
     test_args.SNID = 40120913
 
-    img = ManualFITSImage(
-        header=None, data=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
-        noise=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)), flags=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE))
+    img = FITSImageStdHeaders(
+        header=None,
+        path="none",
+        data=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
+        noise=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
+        flags=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
     )
     img.mjd = 62535.424
     img.band = "Y106"
@@ -264,9 +267,12 @@ def test_build_and_save_lc(cfg):
     cutout_image_list = []
 
     for i in range(len(exposures["date"])):
-        img = ManualFITSImage(
-            header=None, data=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
-            noise=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)), flags=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE))
+        img = FITSImageStdHeaders(
+            header=None,
+            path="none",
+            data=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
+            noise=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
+            flags=np.zeros((ROMAN_IMAGE_SIZE, ROMAN_IMAGE_SIZE)),
         )
         img.mjd = exposures["date"][i]
         img.band = exposures["filter"][i]

--- a/campari/tests/test_simulations.py
+++ b/campari/tests/test_simulations.py
@@ -11,7 +11,7 @@ from erfa import ErfaWarning
 from campari import RomanASP
 from campari.simulation import simulate_galaxy, simulate_images, simulate_supernova, simulate_wcs
 from snappl.diaobject import DiaObject
-from snappl.image import ManualFITSImage
+from snappl.image import FITSImageStdHeaders
 from snpit_utils.logger import SNLogger
 
 warnings.simplefilter("ignore", category=AstropyWarning)
@@ -41,10 +41,19 @@ def test_simulate_images():
 
     image_list = []
     for i in range(10):
-        img = ManualFITSImage(header=None, data=np.zeros((4088, 4088)), noise=np.ones((4088, 4088)),
-                              flags=np.zeros((4088, 4088)), mjd=dates[i], band=band, pointing=base_pointing,
-                              sca=base_sca)
+        img = FITSImageStdHeaders(
+            header=None,
+            path="none",
+            data=np.zeros((4088, 4088)),
+            noise=np.ones((4088, 4088)),
+            flags=np.zeros((4088, 4088)),
+        )
+        img.mjd = dates[i]
+        img.band = band
+        img.pointing = base_pointing
+        img.sca = base_sca
         image_list.append(img)
+        SNLogger.debug(f"Created faux image with MJD {img.mjd}")
 
     simulated_lightcurve, util_ref = simulate_images(
         image_list=image_list,

--- a/campari/tests/test_simulations.py
+++ b/campari/tests/test_simulations.py
@@ -43,7 +43,7 @@ def test_simulate_images():
     for i in range(10):
         img = FITSImageStdHeaders(
             header=None,
-            path="none",
+            path="/dev/null",
             data=np.zeros((4088, 4088)),
             noise=np.ones((4088, 4088)),
             flags=np.zeros((4088, 4088)),

--- a/campari/tests/test_truth.py
+++ b/campari/tests/test_truth.py
@@ -27,7 +27,7 @@ from campari.io import (
 
 from campari.run_one_object import campari_lightcurve_model
 from snappl.diaobject import DiaObject
-from snappl.image import ManualFITSImage
+from snappl.image import FITSImageStdHeaders
 from snappl.imagecollection import ImageCollection
 from snpit_utils.config import Config
 from snpit_utils.logger import SNLogger
@@ -113,11 +113,12 @@ def test_build_lc_and_add_truth(sn_path):
     cutout_image_list = []
 
     for i in range(len(explist["date"])):
-        img = ManualFITSImage(
+        img = FITSImageStdHeaders(
             header=None,
             data=np.zeros((4085, 4085)),
             noise=np.zeros((4085, 4085)),
             flags=np.zeros((4085, 4085)),
+            path="none",
         )
         img.mjd = explist["date"][i]
         img.filter = explist["filter"][i]

--- a/campari/tests/test_truth.py
+++ b/campari/tests/test_truth.py
@@ -118,7 +118,7 @@ def test_build_lc_and_add_truth(sn_path):
             data=np.zeros((4085, 4085)),
             noise=np.zeros((4085, 4085)),
             flags=np.zeros((4085, 4085)),
-            path="none",
+            path="/dev/null",
         )
         img.mjd = explist["date"][i]
         img.filter = explist["filter"][i]

--- a/changes/177.campari.rst
+++ b/changes/177.campari.rst
@@ -1,0 +1,1 @@
+Removed manual fits images


### PR DESCRIPTION
`ManualFITSImage` is no more, so we update to `FITSImageStdHeaders` objects. These are largely the same except:

- [x] All new instances of `FITSImageStdHeaders` require a path. My old ManualFITS did not have nor need paths. Since it is required to be a string, I pass "none".
- [x] Some parameters like mjd and band can no longer be set at init and instead have to be manually set.
- [x] When setting a WCS header, mjd, band, etc. need to be manually set.