### PR TITLE
Removing simulation.py

### DIFF
--- a/campari/campari_runner.py
+++ b/campari/campari_runner.py
@@ -89,9 +89,6 @@ class campari_runner:
         self.weighting = self.cfg.value("photometry.campari.weighting")
         self.pixel = self.cfg.value("photometry.campari.pixel")
         self.sn_truth_dir = self.cfg.value("system.ou24.sn_truth_dir")
-        self.galaxy_photon_ops = self.cfg.value("photometry.campari.psf.galaxy_photon_ops")
-        self.transient_photon_ops = self.cfg.value("photometry.campari.psf.transient_photon_ops")
-        self.source_phot_ops = self.cfg.value("photometry.campari.source_phot_ops")
         self.mismatch_seds = self.cfg.value("photometry.campari_simulations.mismatch_seds")
         self.fetch_SED = self.cfg.value("photometry.campari.fetch_SED")
         self.initial_flux_guess = self.cfg.value("photometry.campari.initial_flux_guess")
@@ -124,8 +121,6 @@ class campari_runner:
             self.grid_type = "regular"
             self.spacing = 9
             self.size = 11
-            self.transient_photon_ops = False
-            self.galaxy_photon_ops = False
             self.fetch_SED = False
             self.make_initial_guess = False
 

--- a/campari/model_building.py
+++ b/campari/model_building.py
@@ -269,7 +269,6 @@ def construct_static_scene(ra=None, dec=None, sca_wcs=None, x_loc=None, y_loc=No
 
     cfg = Config.get()
     psfclass = cfg.value("photometry.campari.psf.galaxy_class")
-    include_photonOps = cfg.value("photometry.campari.psf.galaxy_photon_ops")
 
     num_grid_points = np.size(x_sca)
 
@@ -291,7 +290,7 @@ def construct_static_scene(ra=None, dec=None, sca_wcs=None, x_loc=None, y_loc=No
     sca = image.sca if image is not None else None
 
     psf_object = PSF.get_psf_object(psfclass, pointing=pointing, sca=sca, size=stampsize, stamp_size=stampsize,
-                                    include_photonOps=include_photonOps, seed=None, image=image)
+                                    seed=None, image=image)
     # See run_one_object documentation to explain this pixel coordinate conversion.
     x_loc = int(np.floor(x_loc + 0.5))
     y_loc = int(np.floor(y_loc + 0.5))
@@ -359,7 +358,7 @@ def construct_transient_scene(
 
     SNLogger.debug(f"Using psf class {snpsfclass}")
     psf_object = PSF.get_psf_object(
-        snpsfclass, pointing=pointing, sca=sca, size=stampsize, include_photonOps=photOps,
+        snpsfclass, pointing=pointing, sca=sca, size=stampsize,
         image=image, stamp_size=stampsize
     )
     psf_image = psf_object.get_stamp(x0=x0, y0=y0, x=x, y=y, flux=1.0)
@@ -558,7 +557,7 @@ def make_contour_grid(img_obj, numlevels=None, percentiles=[0, 90, 98, 100], sub
 
 def build_model_for_one_image(image=None, ra=None, dec=None, use_real_images=None, grid_type=None, ra_grid=None,
                               dec_grid=None, size=None, pixel=False, band=None, sedlist=None,
-                              source_phot_ops=None, image_index=None, num_total_images=None, num_detect_images=None,
+                              image_index=None, num_total_images=None, num_detect_images=None,
                               prebuilt_psf_matrix=None, prebuilt_sn_matrix=None, subtract_background_method=None):
 
     # Passing in None for the PSF means we use the Roman PSF.

--- a/campari/run_one_object.py
+++ b/campari/run_one_object.py
@@ -141,6 +141,9 @@ def run_one_object(diaobj=None, object_type=None, image_list=None, size=None, ba
         LSB = calculate_local_surface_brightness(cutout_image_list, cutout_pix=2)
 
     # Build the backgrounds loop
+    cfg = Config.get()
+    psfclass = cfg.get().value("photometry.campari.psf.transient_class")
+
     model_results = []
     kwarg_dict = {"ra": diaobj.ra, "dec": diaobj.dec, "grid_type": grid_type,
                   "ra_grid": ra_grid, "dec_grid": dec_grid, "size": size, "pixel": pixel,

--- a/campari/tests/test_gausspsfs_realistichosts.py
+++ b/campari/tests/test_gausspsfs_realistichosts.py
@@ -1,0 +1,141 @@
+
+import pathlib
+import pytest
+import subprocess
+
+import numpy as np
+
+from astropy.table import Table
+
+from snappl.logger import SNLogger
+
+from campari.plotting import generate_diagnostic_plots
+from campari.tests.test_gausspsfs import perform_gaussianity_checks, create_true_flux
+
+
+from snappl.config import Config
+
+
+imsize = 19
+base_cmd = [
+        "python", "../RomanASP.py",
+        "--diaobject-name", "123",
+        "-t", "1",
+        "-n", "0",
+        "-f", "R062",
+        "--ra", "128.0",
+        "--dec", "42.0",
+        "--transient_start", "60010",
+        "--transient_end", "60060",
+        "--photometry-campari-use_real_images",
+        "--photometry-campari-psf-transient_class", "gaussian",
+        "--photometry-campari-psf-galaxy_class", "gaussian",
+        "--diaobject-collection", "manual",
+        "--no-photometry-campari-fetch_SED",
+        "--photometry-campari-grid_options-spacing", "1",
+        "--photometry-campari-grid_options-subsize", "4",
+        "--photometry-campari-cutout_size", str(imsize),
+        "--photometry-campari-weighting",
+        "--photometry-campari-subtract_background_method", "calculate",
+        "--no-photometry-campari-source_phot_ops",
+        "--image-collection", "manual_fits",
+        "--photometry-campari_simulations-run_name", "gauss_source_no_grid",
+        "--image-collection-basepath", "/photometry_test_data/simple_gaussian_test/sig1.0",
+        "--image-collection-subset", "threefile",
+        "--no-save-to-db"
+    ]
+
+
+cfg = Config.get()
+debug_dir = cfg.value("system.paths.debug_dir")
+
+
+# Right now this is failing due to a skew. I believe this is
+# due to some bias resulting from the low SNR + Poisson noise when doing PSF fitting. More work is needed, come
+# back to this! XXX XXX XXX TODO XXX
+@pytest.mark.skip(reason="This test fails due to skew. I need to"
+" figure out if this is due to the fact that it is noiseless.")
+def test_faint_transient_nonoise_unlaligned_realisticgalaxy():
+    cmd = base_cmd + [
+        "--img_list",
+        pathlib.Path(__file__).parent
+        / "testdata/test_gaussims_nonoise_faintsource_unaligned_positionfixed_realisticgal_seed45.txt",
+    ]
+
+    cmd += ["--photometry-campari-grid_options-type", "regular"]
+    spacing_index = cmd.index("--photometry-campari-grid_options-spacing")
+    cmd[spacing_index + 1] = "0.75"  # Finer grid spacing
+
+    cmd += [
+        "--prebuilt_static_model",
+        pathlib.Path(__file__).parent / "testdata/prebuilt_models/gauss250images_36points.npy",
+    ]
+
+    result = subprocess.run(cmd, capture_output=False, text=True)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed with exit code {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    # Check accuracy
+    lc = Table.read("/campari_out_dir/123_R062_gaussian_lc.ecsv")
+
+    flux = create_true_flux(lc["mjd"], peakmag=24)
+
+    try:
+        # With the more realistic galaxies, it is harder for campari to perfectly model the galaxy.
+        # At this grid scale, it seems like the impact is about a scatter of 75 counts in flux.
+        # Aka, I beleive that at the current grid scale, there is an error floor of 75 counts
+        # even without noise. This is determined empiraclly from the code. It is possible this could
+        # be reduced through improvements to the algorithm or finer grid spacing, but for now we
+        # will just account for it here.
+        lc["flux_err"] = np.sqrt(lc["flux_err"] ** 2 + 75**2)
+        residuals_sigma = (lc["flux"] - flux) / lc["flux_err"]
+        perform_gaussianity_checks(residuals_sigma)
+    except AssertionError as e:
+        plotname = "fainttransient_nonoise_hostrealistic_diagnostic"
+        generate_diagnostic_plots("123_R062_gaussian", imsize, plotname, trueflux=flux, err_fudge=75)
+
+        SNLogger.debug(e)
+        raise e
+
+
+def test_faint_transient_bothnoise_unlaligned_realisticgalaxy():
+    cmd = base_cmd + [
+        "--img_list",
+        pathlib.Path(__file__).parent
+        / "testdata/test_gaussims_bothnoise_faintsource_unaligned_positionfixed_realisticgal_seed45.txt",
+    ]
+
+    cmd += ["--photometry-campari-grid_options-type", "regular"]
+    spacing_index = cmd.index("--photometry-campari-grid_options-spacing")
+    cmd[spacing_index + 1] = "0.75"  # Finer grid spacing
+
+    # realsitic_galaxy_gridmodel
+    cmd += [
+        "--prebuilt_static_model",
+        pathlib.Path(__file__).parent / "testdata/prebuilt_models/gauss250images_36points.npy",
+    ]
+
+    result = subprocess.run(cmd, capture_output=False, text=True)
+
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed with exit code {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    # Check accuracy
+    lc = Table.read("/campari_out_dir/123_R062_gaussian_lc.ecsv")
+
+    flux = create_true_flux(lc["mjd"], peakmag=24)
+
+    try:
+        residuals_sigma = (lc["flux"] - flux) / lc["flux_err"]
+        perform_gaussianity_checks(residuals_sigma)
+    except AssertionError as e:
+        plotname = "fainttransient_nonoise_hostrealistic_diagnostic"
+        generate_diagnostic_plots("123_R062_gaussian", imsize, plotname, trueflux=flux)
+        SNLogger.debug(f"Generated saved diagnostic plots to {debug_dir}/{plotname}.png")
+        SNLogger.debug(e)
+        raise e

--- a/campari/tests/test_runner.py
+++ b/campari/tests/test_runner.py
@@ -71,10 +71,6 @@ def create_default_test_args(cfg):
     test_args.subtract_background_method = config.value("photometry.campari.subtract_background_method")
     test_args.weighting = config.value("photometry.campari.weighting")
     test_args.pixel = config.value("photometry.campari.pixel")
-    test_args.source_phot_ops = config.value("photometry.campari.source_phot_ops")
-    test_args.transient_photon_ops = config.value("photometry.campari.psf.transient_photon_ops")
-    # This will need to go away once the PSF object is split in phot ops and non phot ops
-    test_args.galaxy_photon_ops = config.value("photometry.campari.psf.galaxy_photon_ops")
     test_args.mismatch_seds = config.value("photometry.campari_simulations.mismatch_seds")
     test_args.fetch_SED = config.value("photometry.campari.fetch_SED")
     test_args.initial_flux_guess = config.value("photometry.campari.initial_flux_guess")

--- a/campari/tests/testdata/saved_lc_file.ecsv
+++ b/campari/tests/testdata/saved_lc_file.ecsv
@@ -20,7 +20,6 @@
 # - {cutout_size: 11}
 # - {initial_flux_guess: 3000}
 # - {fetch_SED: false}
-# - {source_phot_ops: true}
 # - {use_roman: true}
 # - {weighting: true}
 # - {make_initial_guess: true}

--- a/campari/tests/testdata/saved_lc_file_with_truth.ecsv
+++ b/campari/tests/testdata/saved_lc_file_with_truth.ecsv
@@ -24,7 +24,6 @@
 # - {cutout_size: 11}
 # - {initial_flux_guess: 3000}
 # - {fetch_SED: false}
-# - {source_phot_ops: true}
 # - {use_roman: true}
 # - {weighting: true}
 # - {make_initial_guess: true}

--- a/campari/tests/testdata/test_build_lc.ecsv
+++ b/campari/tests/testdata/test_build_lc.ecsv
@@ -20,7 +20,6 @@
 # - {cutout_size: 11}
 # - {initial_flux_guess: 3000}
 # - {fetch_SED: false}
-# - {source_phot_ops: true}
 # - {use_roman: true}
 # - {weighting: true}
 # - {make_initial_guess: true}
@@ -28,7 +27,7 @@
 # - {pixel: false}
 # - {subtract_background_method: calculate}
 # - {use_real_images: true}
-# - psf: {galaxy_class: ou24PSF, galaxy_photon_ops: false, transient_class: ou24PSF, transient_photon_ops: false}
+# - psf: {galaxy_class: ou24PSF, transient_class: ou24PSF_slow}
 # - grid_options:
 #     cutoff: 4
 #     error_floor: 1

--- a/campari/tests/testdata/test_lc.ecsv
+++ b/campari/tests/testdata/test_lc.ecsv
@@ -24,7 +24,6 @@
 # - {cutout_size: 19}
 # - {initial_flux_guess: 3000}
 # - {fetch_SED: false}
-# - {source_phot_ops: false}
 # - {use_roman: true}
 # - {weighting: true}
 # - {make_initial_guess: true}

--- a/campari/tests/testdata/test_star_lc.ecsv
+++ b/campari/tests/testdata/test_star_lc.ecsv
@@ -20,7 +20,6 @@
 # - {cutout_size: 11}
 # - {initial_flux_guess: 3000}
 # - {fetch_SED: false}
-# - {source_phot_ops: true}
 # - {use_roman: true}
 # - {weighting: true}
 # - {make_initial_guess: true}
@@ -87,4 +86,4 @@
 #       value: !astropy.table.SerializedColumn {name: zpt}
 # schema: astropy-2.0
 mjd flux flux_err zpt NEA sky_rms pointing sca pix_x pix_y mag_fit mag_fit_err x_cutout y_cutout sky_background
-62455.669 358947.2808195439 140.32042735334673 15.023547191066584 0.0 0.0 35198 2 286.23733052601574 1091.4859035809764 18.77407908404276 0.00042443828491140997 5.237330526571221 5.485903585548659 108.0
+62455.669 358946.94104248745 140.32030417896212 15.023547191066584 0.0 0.0 35198 2 286.23733052601574 1091.4859035809764 18.77408011179376 0.000424438314106539 5.237330526571221 5.485903585548659 108.0

--- a/changes/223.campari
+++ b/changes/223.campari
@@ -1,0 +1,1 @@
+Removed direct references to the photon ops kwarg

--- a/changes/224.campari.rst
+++ b/changes/224.campari.rst
@@ -1,1 +1,1 @@
-Add your info here
+Fixed a merge conflict.

--- a/changes/225.campari.rst
+++ b/changes/225.campari.rst
@@ -1,0 +1,1 @@
+Added realistic galaxy gaussian PSF tests

--- a/examples/perlmutter/campari_config_test.yaml
+++ b/examples/perlmutter/campari_config_test.yaml
@@ -4,7 +4,6 @@ photometry:
     cutout_size: 11
     initial_flux_guess: 3000
     fetch_SED: false
-    source_phot_ops: true
     use_roman: true
     weighting: true
     make_initial_guess: true
@@ -14,8 +13,6 @@ photometry:
     use_real_images: true
 
     psf:
-      galaxy_photon_ops: false
-      transient_photon_ops: false
       galaxy_class: ou24PSF
       transient_class: ou24PSF_slow
 


### PR DESCRIPTION
Ignore the title of the branch. In this PR, we remove the simulation.py and code that utilized it from campari. This got rid of a lot of annoying if then statements which hinged on the data being real or simulated.

This branch was originally the branch on which I was adding SED tests. I accidentally made all the removing simulation changes on this branch, so I went back and made a separate branch of the SED test branch which I'll make a PR for shortly. That is why there are new tests, but those are also included in another PR so they will not be a new change once I have merged the real SED testing branch.